### PR TITLE
Prepare for release 7.0.5-v6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	kmodules.xyz/custom-resources v0.25.0
 	kmodules.xyz/offshoot-api v0.25.0
 	kubedb.dev/apimachinery v0.28.4-0.20220918021210-a0b96812228b
-	stash.appscode.dev/apimachinery v0.28.1-0.20230429131740-425734e18c7c
+	stash.appscode.dev/apimachinery v0.29.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -914,5 +914,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kF
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.28.1-0.20230429131740-425734e18c7c h1:X5nxy4AApyos2sHrIzoZpEcsT8vMdzqdusz2U+BhlKY=
-stash.appscode.dev/apimachinery v0.28.1-0.20230429131740-425734e18c7c/go.mod h1:7ao2U0Jgntc10uRf9KRmzXuabO12Nm7+2WpcRE/ZXWo=
+stash.appscode.dev/apimachinery v0.29.0 h1:36ijvg31s2UDQIAN2lnYY76E9dydUADutTkkErqokAQ=
+stash.appscode.dev/apimachinery v0.29.0/go.mod h1:7ao2U0Jgntc10uRf9KRmzXuabO12Nm7+2WpcRE/ZXWo=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -682,7 +682,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.28.1-0.20230429131740-425734e18c7c
+# stash.appscode.dev/apimachinery v0.29.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.04.30
Release-tracker: https://github.com/stashed/CHANGELOG/pull/65
Signed-off-by: 1gtm <1gtm@appscode.com>