### PR TITLE
Prepare for release 7.0.5-v19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	kmodules.xyz/custom-resources v0.30.0
 	kmodules.xyz/offshoot-api v0.30.1
 	kubedb.dev/apimachinery v0.47.0
-	stash.appscode.dev/apimachinery v0.41.0
+	stash.appscode.dev/apimachinery v0.42.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -562,5 +562,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-stash.appscode.dev/apimachinery v0.41.0 h1:1K4j0ADKjlQ/tGnCpctEmDx1CfJzu1HKgQC0EK5U4ZA=
-stash.appscode.dev/apimachinery v0.41.0/go.mod h1:y1VgM/7CT990qqHAtE0JGg1N0sFWzmrq/9HzUU5V8dc=
+stash.appscode.dev/apimachinery v0.42.0 h1:tqGAhAbII/WoYxM4LyQW+Hc6jgjRgBYUcI3AORwBLYs=
+stash.appscode.dev/apimachinery v0.42.0/go.mod h1:Q7iqhJAS0n7IV545NxaYNE5C31bBrWklZj7SfjOyryc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -840,7 +840,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# stash.appscode.dev/apimachinery v0.41.0
+# stash.appscode.dev/apimachinery v0.42.0
 ## explicit; go 1.23.0
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2025.10.17
Release-tracker: https://github.com/stashed/CHANGELOG/pull/85
Signed-off-by: 1gtm <1gtm@appscode.com>